### PR TITLE
TypeError: Only integers, slices (`:`), ellipsis (`...`), tf.newaxis …

### DIFF
--- a/model/validation.py
+++ b/model/validation.py
@@ -29,7 +29,7 @@ class Validation(tf.keras.callbacks.Callback):
 
         for i in range(len(self.generator)):
             batch_images, gt = self.generator[i]
-            pred = self.model.predict_on_batch(batch_images)
+            pred = self.model.predict_on_batch(batch_images).numpy()
 
             pred = self.get_box_highets_percentage(pred)
             gt = self.get_box_highets_percentage(gt)


### PR DESCRIPTION
In tensorflow 2.0.1 it will cause error, so I add .numpy() after pred
```
raise TypeError(_SLICE_TYPE_ERROR + ", got {!r}".format(idx))
TypeError: Only integers, slices (`:`), ellipsis (`...`), tf.newaxis (`None`) and scalar tf.int32/tf.int64 tensors are valid indices, got array([ 0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15])
```